### PR TITLE
modified build config to be compatible with Cloud9 IDE

### DIFF
--- a/assets/index.html
+++ b/assets/index.html
@@ -5,11 +5,11 @@
         <meta charset="utf-8">
         <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
         <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700" rel="stylesheet">
-        <link rel="stylesheet" href="http://localhost:8080/poker/style.css">
+        <link rel="stylesheet" href="{HOSTNAME}/assets/style.css">
     </head>
     <body>
         <div id="content">
         </div>
-        <script type="text/javascript" src="http://localhost:8080/poker/app.js" charset="utf-8"></script>
+        <script type="text/javascript" src="{HOSTNAME}/assets/app.js" charset="utf-8"></script>
     </body>
 </html>

--- a/client/Main.jsx
+++ b/client/Main.jsx
@@ -1,0 +1,7 @@
+import React from 'react'
+
+export default () => (
+    <div>
+        <h1>Planning Poker Yay Best Ever!</h1>
+    </div>
+)

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Planner poker final",
   "main": "index.js",
   "scripts": {
-    "start-ui": "webpack-dev-server --progress --inline --hot",
+    "start-ui": "webpack-dev-server --progress --inline --host 0.0.0.0 --port 8081",
     "start-server": "nodemon ./index.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/server/server.js
+++ b/server/server.js
@@ -1,3 +1,4 @@
+import fs from 'fs'
 import http from 'http'
 import express from 'express'
 import path from 'path'
@@ -6,13 +7,24 @@ import chalk from 'chalk'
 const app = express()
 const server = http.Server(app)
 
-const PORT = process.env.PORT || 8081
 const ENV = process.env.NODE_ENV || 'dev'
+const PORT = /*process.env.PORT ||*/ 8080
+const WEBPACK_HOST = ENV == 'dev' ? (process.env.C9_HOSTNAME || process.env.IP || 'localhost') : ''
+const WEBPACK_PORT = ENV === 'dev' ? 8081 : PORT
+
+const indexHtml = new Promise((resolve, reject) => fs.readFile(
+    path.resolve(__dirname, '..', 'assets', 'index.html'), 
+    (err, data) => err ? reject(err) : 
+        resolve(data.toString().split('{HOSTNAME}').join(`//${WEBPACK_HOST}:${WEBPACK_PORT}`))
+))
 
 app.use('/assets', express.static(
     path.resolve(__dirname, '..', 'assets')))
-app.get('/*', (req, res) => res.sendFile(
-    path.resolve(__dirname, '..', 'assets', 'index.html')))
+    
+app.get('/', (req, res) => indexHtml.then(data => {
+    res.set('Content-Type', 'text/html')
+    res.send(data)
+}))
 
 server.listen(PORT)
 console.log(`Server running on port ${chalk.red(PORT)}, environement: ${chalk.blue(ENV)}`)

--- a/test.js
+++ b/test.js
@@ -1,0 +1,1 @@
+console.log(process.env)

--- a/test.js
+++ b/test.js
@@ -1,1 +1,0 @@
-console.log(process.env)

--- a/ui.jsx
+++ b/ui.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
+import Main from './client/Main'
 
-ReactDOM.render(<p>Hello World.</p>, document.getElementById('content'))
+ReactDOM.render(<Main />, document.getElementById('content'))

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,7 +11,7 @@ module.exports = {
     ],
     output: {
         path: staticFolder,
-        publicPath: 'http://localhost:8080/poker/',
+        publicPath: 'http://localhost:8081/assets/',
         filename: 'app.js'
     },
     devtool: 'eval-source-map',


### PR DESCRIPTION
Modified build process to be compatible with Cloud9 IDE.
- Swapped ports: now the base app is served from port 8080, and WebPack hot reloading uses port 8081.
- Modified server.js: instead of serving index.html as a static file, now we inject the host and port for WebPack hot reloading.
